### PR TITLE
Extend `SubcommandsProvider`

### DIFF
--- a/lib/clientele/src/subcommands.rs
+++ b/lib/clientele/src/subcommands.rs
@@ -48,6 +48,18 @@ impl SubcommandsProvider {
     pub fn iter(&self) -> impl Iterator<Item = &Subcommand> {
         self.commands.iter()
     }
+
+    pub fn into_iter(self) -> impl Iterator<Item = Subcommand> {
+        self.commands.into_iter()
+    }
+
+    pub fn get_commands(&self) -> &Vec<Subcommand> {
+        &self.commands
+    }
+
+    pub fn into_commands(self) -> Vec<Subcommand> {
+        self.commands
+    }
 }
 
 #[cfg(unix)]


### PR DESCRIPTION
This PR extends `SubcommandsProvider` type to expose few methods to better iterate it.

@race-of-sloths include